### PR TITLE
First implementation of summary key values plot

### DIFF
--- a/everviz/config.py
+++ b/everviz/config.py
@@ -2,7 +2,7 @@ import os
 import yaml
 
 from everviz.log import get_logger
-from everviz.pages import controls, crossplot
+from everviz.pages import controls, crossplot, summary_values
 
 
 logger = get_logger()
@@ -16,12 +16,13 @@ def create_everviz_folder(everest_folder):
 
 
 def webviz_config(api):
-    create_everviz_folder(api.output_folder())
+    create_everviz_folder(api.output_folder)
     return {
         "title": "Everest Optimization Report",
         "pages": [
             {"title": "Everest", "content": [],},
             controls.page_layout(api),
+            summary_values.page_layout(api),
             crossplot.page_layout(api),
         ],
     }
@@ -29,5 +30,5 @@ def webviz_config(api):
 
 def write_webviz_config(config, file_path):
     with open(file_path, "w") as fh:
-        yaml.dump(config, fh, default_flow_style=False)
+        yaml.dump(config, fh, default_flow_style=False, sort_keys=False)
     logger.info("Webviz config file created: {}".format(file_path))

--- a/everviz/everest_hooks.py
+++ b/everviz/everest_hooks.py
@@ -20,7 +20,7 @@ except ImportError:
 @hookimpl
 def visualize_data(api):
     file_name = "everviz_webviz_config.yml"
-    everviz_folder = os.path.join(api.output_folder(), "everviz")
+    everviz_folder = os.path.join(api.output_folder, "everviz")
     file_path = os.path.join(everviz_folder, file_name)
     logger = setup_logger(everviz_folder)
 

--- a/everviz/pages/controls.py
+++ b/everviz/pages/controls.py
@@ -25,7 +25,7 @@ def _control_data_initial_vs_best(api):
 
 
 def _set_up_data_sources(api):
-    everest_folder = api.output_folder()
+    everest_folder = api.output_folder
     everviz_path = os.path.join(everest_folder, "everviz")
 
     logger.info("Generating controls per batch source data file")

--- a/everviz/pages/summary_values.py
+++ b/everviz/pages/summary_values.py
@@ -1,0 +1,82 @@
+import os
+import pandas
+import numpy
+from collections import namedtuple
+from functools import partial
+from everviz.log import get_logger
+
+
+DataSources = namedtuple("DataSource", "summary_values")
+
+logger = get_logger()
+
+
+def _summary_values(summary_values):
+    # Rename the batch, simulation, and date columsn.
+    summary_values.rename(
+        columns={"batch": "Batch", "simulation": "Simulation", "date": "Date"},
+        inplace=True,
+    )
+
+    # Find the key names.
+    id_vars = ["Batch", "Date", "Simulation"]
+    value_vars = [column for column in summary_values.columns if column not in id_vars]
+
+    # Make rows out of the keys.
+    summary_values = pandas.melt(
+        summary_values,
+        id_vars=id_vars,
+        value_vars=value_vars,
+        var_name="Summary Key",
+        value_name="Value",
+    )
+
+    # Aggregate the values over the simulations, using pivot_table, keeping the
+    # key, batch and date as the multi-index, calculating statistics of the
+    # values over the simulations.
+    summary_values = pandas.pivot_table(
+        summary_values,
+        values="Value",
+        index=["Summary Key", "Batch", "Date"],
+        aggfunc=[
+            numpy.mean,
+            partial(numpy.quantile, q=0.1),
+            partial(numpy.quantile, q=0.9),
+        ],
+    )
+
+    # Rename the statistics columns.
+    summary_values = summary_values.droplevel(1, axis="columns")
+    summary_values.columns = ["Mean", "P10", "P90"]
+
+    # Sort the multi index, and reset them to columns.
+    return summary_values.sort_index().reset_index()
+
+
+def _set_up_data_sources(api, keys=None):
+    everest_folder = api.output_folder
+    everviz_path = os.path.join(everest_folder, "everviz")
+
+    # Make a table which statistics over the simulations.
+    summary_values = api.summary_values(keys=keys)
+
+    logger.info("Generating summary values plot")
+    summary_values_file = os.path.join(everviz_path, "summary_values.csv")
+    data = _summary_values(summary_values)
+    data.to_csv(summary_values_file, index=False, sep=";")
+    logger.info(f"File created: {summary_values_file}")
+
+    return DataSources(summary_values=summary_values_file,)
+
+
+def page_layout(api):
+    sources = _set_up_data_sources(api)
+    return {
+        "title": "Summary Values",
+        "content": [
+            "## Summary values as a function of date",
+            {"SummaryPlot": {"csv_file": sources.summary_values, "xaxis": "date",},},
+            "## Summary values as a function of batch",
+            {"SummaryPlot": {"csv_file": sources.summary_values, "xaxis": "batch",},},
+        ],
+    }

--- a/everviz/plugins/__init__.py
+++ b/everviz/plugins/__init__.py
@@ -1,2 +1,3 @@
 from everviz.plugins.crossplot.crossplot import Crossplot
 from everviz.plugins.crossplot.crossplot_indexed import CrossplotIndexed
+from everviz.plugins.summary_plot.summary_plot import SummaryPlot

--- a/everviz/plugins/summary_plot/summary_plot.py
+++ b/everviz/plugins/summary_plot/summary_plot.py
@@ -1,0 +1,161 @@
+from pathlib import Path
+import pkg_resources
+from uuid import uuid4
+from collections import deque
+
+import dash_html_components as html
+import dash_core_components as dcc
+from dash.dependencies import Output, Input
+
+import plotly.graph_objs as go
+from plotly.colors import DEFAULT_PLOTLY_COLORS
+
+from webviz_config import WebvizPluginABC
+from everviz.data.load_csv.get_data import get_data
+from webviz_config.webviz_assets import WEBVIZ_ASSETS
+
+
+class SummaryPlot(WebvizPluginABC):
+    def __init__(self, app, csv_file, xaxis="date"):
+        super().__init__()
+        self.xaxis = xaxis
+        self.graph_id = f"graph-{uuid4()}"
+        self.key_dropdown_id = f"dropdown-{uuid4()}"
+        self.xaxis_dropdown_id = f"dropdown-{uuid4()}"
+        self.csv_file = csv_file
+        self.set_callbacks(app)
+
+        ASSETS_DIR = pkg_resources.resource_filename("everviz", "assets")
+        WEBVIZ_ASSETS.add(Path(ASSETS_DIR) / "axis_customization.css")
+
+    def add_webvizstore(self):
+        return [(get_data, [{"csv_file": self.csv_file}])]
+
+    @property
+    def layout(self):
+        data = get_data(self.csv_file)
+        key_dropdown_options = [
+            {"label": i, "value": i} for i in list(data["Summary Key"].unique())
+        ]
+        xaxis_dropdown_options = [
+            {"label": i, "value": i}
+            for i in list(data["Batch" if self.xaxis == "date" else "Date"].unique())
+        ]
+        xaxis_dropdown_title = (
+            "Batches to plot" if self.xaxis == "date" else "Dates to plot"
+        )
+        return html.Div(
+            [
+                html.Div(
+                    [
+                        html.Div(
+                            [
+                                html.Label("Keywords to plot:"),
+                                dcc.Dropdown(
+                                    id=self.key_dropdown_id,
+                                    options=key_dropdown_options,
+                                    multi=True,
+                                ),
+                                html.Label(
+                                    xaxis_dropdown_title, style={"margin-top": 24}
+                                ),
+                                dcc.Dropdown(
+                                    id=self.xaxis_dropdown_id,
+                                    options=xaxis_dropdown_options,
+                                    multi=True,
+                                    value=[xaxis_dropdown_options[0]["value"]],
+                                ),
+                            ],
+                            style={
+                                "width": "29%",
+                                "display": "inline-block",
+                                "vertical-align": "top",
+                            },
+                        ),
+                        html.Div(
+                            [dcc.Graph(id=self.graph_id)],
+                            style={"width": "69%", "display": "inline-block"},
+                        ),
+                    ]
+                ),
+            ]
+        )
+
+    def set_callbacks(self, app):
+        @app.callback(
+            Output(self.graph_id, "figure"),
+            [
+                Input(self.key_dropdown_id, "value"),
+                Input(self.xaxis_dropdown_id, "value"),
+            ],
+        )
+        def update_graph(key_list, line_list):
+            # The key_list arguments is the list of keys to plot. The line_list
+            # argument is a list of batches, or a list of dates to plot for
+            # those keys.
+            if key_list is None or line_list is None:
+                return {}
+
+            # Get the data, setting its index.
+            data = get_data(self.csv_file).set_index(["Summary Key", "Batch", "Date"])
+
+            # Put the the standard colors in a deque that we will rotate.
+            colors = deque(DEFAULT_PLOTLY_COLORS)
+
+            # Choose between dates or batches on the xaxis.
+            line_key = "Batch" if self.xaxis == "date" else "Date"
+            xaxis_key = "Date" if self.xaxis == "date" else "Batch"
+
+            traces = []
+            for key in key_list:
+                # Select all rows belonging to the current key.
+                key_data = data.xs(key, level="Summary Key", drop_level=True)
+
+                for line in line_list:
+                    # Select all rows belonging the current batch or date.
+                    line_data = key_data.xs(
+                        line, level=line_key, drop_level=True
+                    ).reset_index()
+
+                    # Set the name of the plotted line.
+                    name = f"{key}"
+                    if len(line_list) > 1:
+                        name += f", {line_key}:{line}"
+
+                    # Make the traces, with mean, P10 and P90, shading in between.
+                    traces.extend(
+                        [
+                            go.Scatter(
+                                y=line_data["P90"],
+                                x=line_data[xaxis_key],
+                                mode="lines",
+                                marker={"size": 10},
+                                line={"color": colors[0]},
+                                name=name + "(P90)",
+                                showlegend=False,
+                            ),
+                            go.Scatter(
+                                y=line_data["P10"],
+                                x=line_data[xaxis_key],
+                                mode="lines",
+                                line={"color": colors[0]},
+                                marker={"size": 10},
+                                fill="tonexty",
+                                name=name + "(P10)",
+                                showlegend=False,
+                            ),
+                            go.Scatter(
+                                y=line_data["Mean"],
+                                x=line_data[xaxis_key],
+                                mode="lines",
+                                marker={"size": 10},
+                                line={"color": colors[0]},
+                                name=name,
+                                showlegend=True,
+                            ),
+                        ]
+                    )
+
+                    # Cycle trough the default colors.
+                    colors.rotate(-1)
+            return {"data": traces}

--- a/setup.py
+++ b/setup.py
@@ -31,6 +31,7 @@ setup(
         "webviz_config_plugins": [
             "Crossplot = everviz.plugins:Crossplot",
             "CrossplotIndexed = everviz.plugins:CrossplotIndexed",
+            "SummaryPlot = everviz.plugins:SummaryPlot",
         ],
         "everest": ["everviz = everviz.everest_hooks",],
     },

--- a/tests/unit/test_control_plot_data.py
+++ b/tests/unit/test_control_plot_data.py
@@ -58,7 +58,7 @@ expected = [
 @pytest.fixture
 def mocked_api(mocker):
     api_mock = mocker.Mock()
-    api_mock.output_folder.return_value = "everest_output"
+    api_mock.output_folder = "everest_output"
     api_mock.control_values = controls[0]
     api_mock.single_objective_values = objectives[0]
     return api_mock

--- a/tests/unit/test_summary_plot.py
+++ b/tests/unit/test_summary_plot.py
@@ -1,0 +1,55 @@
+import pytest
+import pandas
+import numpy
+from datetime import datetime
+from pathlib import Path
+from everviz.pages.summary_values import _summary_values
+
+test_data = {
+    "simulation": [0, 1, 2, 3, 4, 5],
+    "batch": [0, 1, 2, 0, 1, 2],
+    "date": [
+        datetime(2000, 1, 1),
+        datetime(2000, 2, 1),
+        datetime(2000, 3, 1),
+        datetime(2000, 1, 1),
+        datetime(2000, 2, 1),
+        datetime(2000, 3, 1),
+    ],
+    "key1": [1, 2, 3, 4, 5, 6],
+    "key2": [10, 20, 30, 40, 50, 60],
+}
+
+
+def test_summary_values(request, mocker):
+    summary_values = _summary_values(pandas.DataFrame(test_data))
+
+    assert list(summary_values.columns) == [
+        "Summary Key",
+        "Batch",
+        "Date",
+        "Mean",
+        "P10",
+        "P90",
+    ]
+    assert len(summary_values) == len(test_data["simulation"])
+    assert set(summary_values["Summary Key"]) == set(["key1", "key2"])
+    assert set(summary_values["Batch"]) == set(test_data["batch"])
+    assert set(summary_values["Date"]) == set(
+        [pandas.Timestamp(date) for date in test_data["date"]]
+    )
+
+    mean = []
+    p10 = []
+    p90 = []
+    for key in ["key1", "key2"]:
+        for batch in [0, 1, 2]:
+            simulations = [i for i, b in enumerate(test_data["batch"]) if b == batch]
+            data = numpy.array(test_data[key])[simulations]
+            mean.append(numpy.mean(data))
+            p10.append(numpy.quantile(data, q=0.1))
+            p90.append(numpy.quantile(data, q=0.9))
+
+    assert summary_values["Mean"].to_list() == mean
+    assert summary_values["P10"].to_list() == p10
+    assert summary_values["P90"].to_list() == p90


### PR DESCRIPTION
This is a first implementation of summary key values plots, as a function of batch id, or as a function of date (time-series).

A plugin was made that can plot the summary key values as function of date or of batch. Initially no plot is shown, the user has to choose one or more keys from the dropdown. That dropdown is long, but I found that if the user starts typing it automatically filters that dropdown, so for now I don't think a filter option is needed for the keywords.

Plotted are the mean, P10 and P90, shaded in between. I chose mean and not P50, since that is what our customers insisted on, and that is also what is used in the webviz-surface example. It is a strange choice, so maybe we need to discuss options here.

