### PR TITLE
Fix empty pages

### DIFF
--- a/everviz/config.py
+++ b/everviz/config.py
@@ -9,16 +9,21 @@ logger = get_logger()
 
 
 def webviz_config(api):
+    pages = [
+        {"title": "Everest", "content": [],},
+        controls.page_layout(api),
+        summary_values.page_layout(api),
+        crossplot.page_layout(api),
+        objectives.page_layout(api),
+        configuration.page_layout(api),
+    ]
+
+    # Remove possible empty pages
+    pages = list(filter(None, pages))
+
     return {
         "title": "Everest Optimization Report",
-        "pages": [
-            {"title": "Everest", "content": [],},
-            controls.page_layout(api),
-            summary_values.page_layout(api),
-            crossplot.page_layout(api),
-            configuration.page_layout(api),
-            objectives.page_layout(api),
-        ],
+        "pages": pages,
     }
 
 

--- a/everviz/pages/objectives.py
+++ b/everviz/pages/objectives.py
@@ -27,7 +27,7 @@ def _calc_mean(df):
 
 
 def _set_up_data_sources(api):
-    everest_folder = api.output_folder()
+    everest_folder = api.output_folder
     everviz_path = os.path.join(everest_folder, "everviz")
 
     objective_values = os.path.join(everviz_path, "objective_values.csv")
@@ -45,6 +45,6 @@ def page_layout(api):
         "title": "Objectives",
         "content": [
             "## Objective function values",
-            {"Lineplot": {"data_path": sources.objective_values,},},
+            {"ObjectivesPlot": {"data_path": sources.objective_values,},},
         ],
     }

--- a/everviz/pages/summary_values.py
+++ b/everviz/pages/summary_values.py
@@ -60,6 +60,9 @@ def _set_up_data_sources(api, keys=None):
     # Make a table which statistics over the simulations.
     summary_values = api.summary_values(keys=keys)
 
+    if summary_values.empty:
+        return None
+
     logger.info("Generating summary values plot")
     summary_values_file = os.path.join(everviz_path, "summary_values.csv")
     data = _summary_values(summary_values)
@@ -71,12 +74,25 @@ def _set_up_data_sources(api, keys=None):
 
 def page_layout(api):
     sources = _set_up_data_sources(api)
-    return {
-        "title": "Summary Values",
-        "content": [
-            "## Summary values as a function of date",
-            {"SummaryPlot": {"csv_file": sources.summary_values, "xaxis": "date",},},
-            "## Summary values as a function of batch",
-            {"SummaryPlot": {"csv_file": sources.summary_values, "xaxis": "batch",},},
-        ],
-    }
+    if sources is None:
+        return ""
+    else:
+        return {
+            "title": "Summary Values",
+            "content": [
+                "## Summary values as a function of date",
+                {
+                    "SummaryPlot": {
+                        "csv_file": sources.summary_values,
+                        "xaxis": "date",
+                    },
+                },
+                "## Summary values as a function of batch",
+                {
+                    "SummaryPlot": {
+                        "csv_file": sources.summary_values,
+                        "xaxis": "batch",
+                    },
+                },
+            ],
+        }

--- a/everviz/plugins/objectives_plot/objectives_plot.py
+++ b/everviz/plugins/objectives_plot/objectives_plot.py
@@ -16,7 +16,12 @@ from everviz.data.load_csv.get_data import get_data
 
 class ObjectivesPlot(WebvizPluginABC):
     def __init__(
-        self, app, data_path, x_title, y_title, title="Objective function values"
+        self,
+        app,
+        data_path,
+        x_title="batch",
+        y_title="value",
+        title="Objective function values",
     ):
         super().__init__()
         self.title = title

--- a/tests/unit/test_everviz_config.py
+++ b/tests/unit/test_everviz_config.py
@@ -1,6 +1,7 @@
 import os
-
-from everviz.config import write_webviz_config
+import everviz
+from everviz.config import write_webviz_config, webviz_config
+from everviz.pages import controls, crossplot, configuration, objectives, summary_values
 from everviz.util import DEFAULT_CONFIG
 
 
@@ -11,3 +12,35 @@ def test_write_webviz_config(tmpdir):
         assert not os.path.exists(file_name)
         write_webviz_config(config, file_name)
         assert os.path.exists(file_name)
+
+
+def test_webviz_config(mocker, monkeypatch):
+    monkeypatch.setattr(
+        everviz.pages.controls, "page_layout", mocker.Mock(return_value=""),
+    )
+    monkeypatch.setattr(
+        everviz.pages.crossplot, "page_layout", mocker.Mock(return_value=""),
+    )
+    monkeypatch.setattr(
+        everviz.pages.configuration, "page_layout", mocker.Mock(return_value=""),
+    )
+    monkeypatch.setattr(
+        everviz.pages.objectives, "page_layout", mocker.Mock(return_value=""),
+    )
+    monkeypatch.setattr(
+        everviz.pages.summary_values,
+        "page_layout",
+        mocker.Mock(return_value={"title": "Summary", "content": []}),
+    )
+
+    expected_config = {
+        "title": "Everest Optimization Report",
+        "pages": [
+            {"title": "Everest", "content": [],},
+            {"title": "Summary", "content": [],},
+        ],
+    }
+
+    config = webviz_config(mocker.Mock())
+
+    assert expected_config == config

--- a/tests/unit/test_objective_plot_data.py
+++ b/tests/unit/test_objective_plot_data.py
@@ -46,7 +46,7 @@ def test_p10_p90(header_1, header_2):
 
 def test_set_up_sources(mocker, monkeypatch, tmpdir):
     mock_api = mocker.Mock()
-    mock_api.output_folder.return_value = tmpdir
+    mock_api.output_folder = tmpdir
     os.mkdir(os.path.join(tmpdir, "everviz"))
     monkeypatch.setattr(
         everviz.pages.objectives,


### PR DESCRIPTION
It appears webviz does not take to kindly to empty strings as pages `""` which I assumed were fine, I was sure I tested that.  
This PR should fix that and also 

* Check if API returns summary values if not return empty page for summary values
* Add defaults for x and y titles `batch` and `value` 
* Fix plugin name `ObjectivesPlot`in objectives page layout