### PR TITLE
Fix usage of 'realization' vs 'simulation'

### DIFF
--- a/everviz/pages/deltaplot.py
+++ b/everviz/pages/deltaplot.py
@@ -21,11 +21,10 @@ def _get_objective_delta_values(api, best_batch):
 
 
 def _get_summary_delta_values(api, best_batch):
-    data = api.summary_values()
-    if "realization" in data.columns:
-        data = data.drop(columns="realization")
-    data = data.rename(columns={"simulation": "realization"}).set_index(
-        ["realization", "date"]
+    data = (
+        api.summary_values()
+        .drop(columns="simulation")
+        .set_index(["realization", "date"])
     )
     initial = data[(data.batch == 0)].drop(columns=["batch"])
     best = data[data.batch == best_batch].drop(columns=["batch"])

--- a/everviz/pages/objectives.py
+++ b/everviz/pages/objectives.py
@@ -27,9 +27,9 @@ def _total_objective_values_from_api(api):
 
 def _objective_values(data):
     # Sort by the index columns.
-    data = data.drop(columns=["realization"])
+    data = data.drop(columns=["simulation"])
     sorted_values = (
-        data.set_index(["function", "batch", "simulation"]).sort_index().reset_index()
+        data.set_index(["function", "batch", "realization"]).sort_index().reset_index()
     )
     return sorted_values
 
@@ -41,9 +41,9 @@ def _total_objective_values(data):
 
 
 def _objective_statistics(data):
-    # Aggregate the values over the simulations, using pivot_table, keeping the
+    # Aggregate the values over the realizations, using pivot_table, keeping the
     # batch and function as the multi-index, calculating statistics of the
-    # values over the simulations.
+    # values over the realizations.
     statistics = pd.pivot_table(
         data,
         values="value",

--- a/tests/integration/delta_plot/test_summary_delta_plot_integration.py
+++ b/tests/integration/delta_plot/test_summary_delta_plot_integration.py
@@ -6,6 +6,7 @@ from everviz.plugins.delta_plot.delta_plot import DeltaPlot
 from everviz.pages.deltaplot import _get_summary_delta_values
 
 _SUMMARY = {
+    "realization": 3 * [1] + 3 * [2] + 3 * [1] + 3 * [2],
     "simulation": 3 * [1] + 3 * [2] + 3 * [1] + 3 * [2],
     "batch": [0] * 6 + [2] * 6,
     "date": 4
@@ -18,7 +19,7 @@ _SUMMARY = {
     "key2": range(10, 130, 10),
 }
 
-_EMPTY_SUMMARY = {"simulation": [], "date": [], "batch": []}
+_EMPTY_SUMMARY = {"realization": [], "simulation": [], "date": [], "batch": []}
 
 
 def test_summary_delta_plot_callback(app, dash_duo, mocker, caplog):

--- a/tests/integration/objectives_plot/test_objectives_plot_integration.py
+++ b/tests/integration/objectives_plot/test_objectives_plot_integration.py
@@ -5,14 +5,14 @@ from everviz.pages.objectives import _objective_values, _objective_statistics
 
 def test_objective_plot_callback(app, dash_duo, mocker, caplog):
     test_data = [
-        {"batch": 0, "realization": 1, "function": "f0", "value": 100, "simulation": 0},
+        {"batch": 0, "realization": 1, "function": "f0", "value": 100, "simulation": 1},
         {"batch": 0, "realization": 1, "function": "f1", "value": 200, "simulation": 1},
         {"batch": 2, "realization": 2, "function": "f0", "value": 200, "simulation": 2},
-        {"batch": 2, "realization": 2, "function": "f1", "value": 400, "simulation": 3},
-        {"batch": 0, "realization": 3, "function": "f0", "value": 300, "simulation": 4},
-        {"batch": 0, "realization": 3, "function": "f1", "value": 600, "simulation": 5},
-        {"batch": 2, "realization": 4, "function": "f0", "value": 400, "simulation": 6},
-        {"batch": 2, "realization": 4, "function": "f1", "value": 800, "simulation": 7},
+        {"batch": 2, "realization": 2, "function": "f1", "value": 400, "simulation": 2},
+        {"batch": 0, "realization": 1, "function": "f0", "value": 300, "simulation": 1},
+        {"batch": 0, "realization": 1, "function": "f1", "value": 600, "simulation": 1},
+        {"batch": 2, "realization": 2, "function": "f0", "value": 400, "simulation": 2},
+        {"batch": 2, "realization": 2, "function": "f1", "value": 800, "simulation": 2},
     ]
 
     def mock_get_data(data_type):

--- a/tests/integration/summary_plot/test_summary_plot_integration.py
+++ b/tests/integration/summary_plot/test_summary_plot_integration.py
@@ -6,6 +6,7 @@ from everviz.pages.summary_values import _summary_values, _summary_statistics
 
 def test_summary_plot_callback(app, dash_duo, mocker, caplog):
     test_data = {
+        "realization": range(12),
         "simulation": range(12),
         "batch": [0] * 6 + [1] * 6,
         "date": [

--- a/tests/unit/test_delta_plot_data.py
+++ b/tests/unit/test_delta_plot_data.py
@@ -22,6 +22,7 @@ _OBJECTIVES = [
 ]
 
 _SUMMARY = {
+    "realization": 3 * [1] + 3 * [2] + 3 * [1] + 3 * [2],
     "simulation": 3 * [1] + 3 * [2] + 3 * [1] + 3 * [2],
     "batch": [0] * 6 + [2] * 6,
     "date": 4
@@ -92,7 +93,7 @@ def test_delta_plot_layout_with_empty_summary(mocker, tmpdir):
     mock_api.objective_values = _OBJECTIVES
     mock_api.single_objective_values = _SINGLE_OBJECTIVES
     mock_api.summary_values.return_value = pandas.DataFrame(
-        {"simulation": [], "date": [], "batch": []}
+        {"realization": [], "simulation": [], "date": [], "batch": []}
     )
     mock_api.output_folder = tmpdir
 

--- a/tests/unit/test_objective_plot_data.py
+++ b/tests/unit/test_objective_plot_data.py
@@ -12,14 +12,14 @@ from everviz.pages.objectives import (
 )
 
 OBJECTIVES = [
-    {"batch": 0, "realization": 1, "function": "f0", "value": 100, "simulation": 0},
+    {"batch": 0, "realization": 1, "function": "f0", "value": 100, "simulation": 1},
     {"batch": 0, "realization": 1, "function": "f1", "value": 200, "simulation": 1},
     {"batch": 2, "realization": 2, "function": "f0", "value": 200, "simulation": 2},
-    {"batch": 2, "realization": 2, "function": "f1", "value": 400, "simulation": 3},
-    {"batch": 0, "realization": 3, "function": "f0", "value": 300, "simulation": 4},
-    {"batch": 0, "realization": 3, "function": "f1", "value": 600, "simulation": 5},
-    {"batch": 2, "realization": 4, "function": "f0", "value": 400, "simulation": 6},
-    {"batch": 2, "realization": 4, "function": "f1", "value": 800, "simulation": 7},
+    {"batch": 2, "realization": 2, "function": "f1", "value": 400, "simulation": 2},
+    {"batch": 0, "realization": 1, "function": "f0", "value": 300, "simulation": 1},
+    {"batch": 0, "realization": 1, "function": "f1", "value": 600, "simulation": 1},
+    {"batch": 2, "realization": 2, "function": "f0", "value": 400, "simulation": 2},
+    {"batch": 2, "realization": 2, "function": "f1", "value": 800, "simulation": 2},
 ]
 
 
@@ -31,13 +31,13 @@ def test_objective_values_data_frame():
         "batch",
         "function",
         "value",
-        "simulation",
+        "realization",
     }
     assert len(objective_values) == len(OBJECTIVES)
     assert set(objective_values["batch"]) == {obj["batch"] for obj in OBJECTIVES}
     assert set(objective_values["function"]) == {obj["function"] for obj in OBJECTIVES}
-    assert set(objective_values["simulation"]) == {
-        obj["simulation"] for obj in OBJECTIVES
+    assert set(objective_values["realization"]) == {
+        obj["realization"] for obj in OBJECTIVES
     }
 
 

--- a/tests/unit/test_summary_plot.py
+++ b/tests/unit/test_summary_plot.py
@@ -10,6 +10,7 @@ from everviz.pages.summary_values import (
 )
 
 __TEST_DATA = {
+    "realization": range(12),
     "simulation": range(12),
     "batch": [0] * 6 + [1] * 6,
     "date": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 envlist = 
-    py37
+    py3
     linting
     docs
     formatting


### PR DESCRIPTION
Fix the inconsistent use of 'realization' vs 'simulation' throughout the code, which is now possible as the everest data API has been fixed to return realization IDs properly.

closes #98 