### PR TITLE
Add filtering of realizations to the summary plots

### DIFF
--- a/everviz/pages/summary_values.py
+++ b/everviz/pages/summary_values.py
@@ -1,69 +1,23 @@
 import os
 from collections import namedtuple
-from functools import partial
-
-import pandas
-import numpy
 
 from everviz.log import get_logger
 
 
-DataSources = namedtuple("DataSource", ["summary_values", "summary_statistics"])
+DataSources = namedtuple("DataSource", ["summary_values"])
 
 logger = get_logger()
-
-_SUMMARY_INDEX_COLUMNS = ["batch", "date", "realization"]
 
 
 def _summary_values(summary_values):
     # Sort by the index columns.
     sorted_values = (
         summary_values.drop(columns="simulation")
-        .set_index(_SUMMARY_INDEX_COLUMNS)
+        .set_index(["batch", "date", "realization"])
         .sort_index()
         .reset_index()
     )
     return sorted_values
-
-
-def _summary_statistics(summary_values):
-    summary_values = summary_values.drop(columns="simulation")
-
-    # Find the key names.
-    value_vars = [
-        column
-        for column in summary_values.columns
-        if column not in _SUMMARY_INDEX_COLUMNS
-    ]
-
-    # Make rows out of the keys for statistics.
-    reshaped_summary_values = pandas.melt(
-        summary_values,
-        id_vars=_SUMMARY_INDEX_COLUMNS,
-        value_vars=value_vars,
-        var_name="summary_key",
-        value_name="value",
-    )
-
-    # Aggregate the values over the realizations, using pivot_table, keeping the
-    # key, batch and date as the multi-index, calculating statistics of the
-    # values over the realizations.
-    summary_statistics = pandas.pivot_table(
-        reshaped_summary_values,
-        values="value",
-        index=["summary_key", "batch", "date"],
-        aggfunc=[
-            numpy.mean,
-            partial(numpy.quantile, q=0.1),
-            partial(numpy.quantile, q=0.9),
-        ],
-    ).droplevel(1, axis="columns")
-    summary_statistics.columns = ["mean", "P10", "P90"]
-
-    # Sort the multi index, and reset them to columns.
-    sorted_statistics = summary_statistics.sort_index().reset_index()
-
-    return sorted_statistics
 
 
 def _set_up_data_sources(api, keys=None):
@@ -83,14 +37,7 @@ def _set_up_data_sources(api, keys=None):
     values.to_csv(summary_values_file, index=False)
     logger.info(f"File created: {summary_values_file}")  # pylint: disable=W1203
 
-    summary_statistics_file = os.path.join(everviz_path, "summary_statistics.csv")
-    statistics = _summary_statistics(summary_values)
-    statistics.to_csv(summary_statistics_file, index=False)
-    logger.info(f"File created: {summary_statistics_file}")  # pylint: disable=W1203
-
-    return DataSources(
-        summary_values=summary_values_file, summary_statistics=summary_statistics_file,
-    )
+    return DataSources(summary_values=summary_values_file)
 
 
 def page_layout(api):
@@ -103,20 +50,8 @@ def page_layout(api):
         "title": "Summary Values",
         "content": [
             "## Summary values as a function of date",
-            {
-                "SummaryPlot": {
-                    "values_file": sources.summary_values,
-                    "statistics_file": sources.summary_statistics,
-                    "xaxis": "date",
-                },
-            },
+            {"SummaryPlot": {"csv_file": sources.summary_values, "xaxis": "date",},},
             "## Summary values as a function of batch",
-            {
-                "SummaryPlot": {
-                    "values_file": sources.summary_values,
-                    "statistics_file": sources.summary_statistics,
-                    "xaxis": "batch",
-                },
-            },
+            {"SummaryPlot": {"csv_file": sources.summary_values, "xaxis": "batch",},},
         ],
     }

--- a/everviz/plugins/objectives_plot/objectives_plot.py
+++ b/everviz/plugins/objectives_plot/objectives_plot.py
@@ -13,8 +13,9 @@ from dash.dependencies import Output, Input, State
 from webviz_config import WebvizPluginABC
 from webviz_config.webviz_assets import WEBVIZ_ASSETS
 from everviz.data.load_csv.get_data import get_data
+from everviz.util import parse_range
 
-from .util import parse_range, calculate_statistics
+from .util import calculate_statistics
 
 
 class ObjectivesPlot(WebvizPluginABC):

--- a/everviz/plugins/objectives_plot/util.py
+++ b/everviz/plugins/objectives_plot/util.py
@@ -4,22 +4,6 @@ import pandas as pd
 import numpy as np
 
 
-def parse_range(numbers):
-    result = set()
-    if numbers is not None:
-        for number in numbers.split(","):
-            number = number.strip()
-            if number.isdigit():
-                result.add(int(number))
-            elif "-" in number:
-                number_range = number.split("-")
-                start = number_range[0]
-                stop = number_range[1]
-                if start.isdigit() and stop.isdigit():
-                    result |= set(range(int(start), int(stop) + 1))
-    return result
-
-
 def calculate_statistics(data):
     data = pd.pivot_table(
         data,

--- a/everviz/plugins/summary_plot/util.py
+++ b/everviz/plugins/summary_plot/util.py
@@ -1,0 +1,42 @@
+from functools import partial
+
+import pandas
+import numpy
+
+
+def calculate_statistics(summary_values):
+    # Find the key names.
+    value_vars = [
+        column
+        for column in summary_values.columns
+        if column not in ["batch", "date", "realization"]
+    ]
+
+    # Make rows out of the keys for statistics.
+    reshaped_summary_values = pandas.melt(
+        summary_values,
+        id_vars=["batch", "date", "realization"],
+        value_vars=value_vars,
+        var_name="summary_key",
+        value_name="value",
+    )
+
+    # Aggregate the values over the realizations, using pivot_table, keeping the
+    # key, batch and date as the multi-index, calculating statistics of the
+    # values over the realizations.
+    summary_statistics = pandas.pivot_table(
+        reshaped_summary_values,
+        values="value",
+        index=["summary_key", "batch", "date"],
+        aggfunc=[
+            numpy.mean,
+            partial(numpy.quantile, q=0.1),
+            partial(numpy.quantile, q=0.9),
+        ],
+    ).droplevel(1, axis="columns")
+    summary_statistics.columns = ["mean", "P10", "P90"]
+
+    # Sort the multi index, and reset them to columns.
+    sorted_statistics = summary_statistics.sort_index().reset_index()
+
+    return sorted_statistics

--- a/everviz/util.py
+++ b/everviz/util.py
@@ -23,3 +23,19 @@ def identify_indexed_controls(controls):
             continue
 
     return base_names
+
+
+def parse_range(numbers):
+    result = set()
+    if numbers is not None:
+        for number in numbers.split(","):
+            number = number.strip()
+            if number.isdigit():
+                result.add(int(number))
+            elif "-" in number:
+                number_range = number.split("-")
+                start = number_range[0]
+                stop = number_range[1]
+                if start.isdigit() and stop.isdigit():
+                    result |= set(range(int(start), int(stop) + 1))
+    return result

--- a/tests/integration/objectives_plot/test_objectives_plot_integration.py
+++ b/tests/integration/objectives_plot/test_objectives_plot_integration.py
@@ -1,7 +1,6 @@
 import pandas as pd
 from everviz.plugins.objectives_plot.objectives_plot import ObjectivesPlot
 from everviz.pages.objectives import _objective_values
-from everviz.plugins.objectives_plot.util import calculate_statistics
 
 
 def test_objective_plot_callback(app, dash_duo, mocker, caplog):
@@ -80,15 +79,9 @@ def test_objective_plot_callback(app, dash_duo, mocker, caplog):
         },
     ]
 
-    def mock_get_data(data_type):
-        result = _objective_values(pd.DataFrame(test_data))
-        if data_type == "Statistics":
-            result = calculate_statistics(result)
-        return result
-
     mocker.patch(
         "everviz.plugins.objectives_plot.objectives_plot.get_data",
-        side_effect=mock_get_data,
+        return_value=_objective_values(pd.DataFrame(test_data)),
     )
 
     plugin = ObjectivesPlot(app, "values")

--- a/tests/integration/summary_plot/test_summary_plot_integration.py
+++ b/tests/integration/summary_plot/test_summary_plot_integration.py
@@ -1,7 +1,7 @@
 from datetime import datetime
 import pandas as pd
 from everviz.plugins.summary_plot.summary_plot import SummaryPlot
-from everviz.pages.summary_values import _summary_values, _summary_statistics
+from everviz.pages.summary_values import _summary_values
 
 
 def test_summary_plot_callback(app, dash_duo, mocker, caplog):
@@ -27,26 +27,29 @@ def test_summary_plot_callback(app, dash_duo, mocker, caplog):
         "key2": range(10, 130, 10),
     }
 
-    def mock_get_data(data_type):
-        if data_type == "values":
-            result = _summary_values(pd.DataFrame(test_data))
-        else:
-            result = _summary_statistics(pd.DataFrame(test_data))
-        return result
-
     mocker.patch(
-        "everviz.plugins.summary_plot.summary_plot.get_data", side_effect=mock_get_data,
+        "everviz.plugins.summary_plot.summary_plot.get_data",
+        return_value=_summary_values(pd.DataFrame(test_data)),
     )
 
-    plugin = SummaryPlot(app, "values", "statistics")
+    plugin = SummaryPlot(app, "values")
     app.layout = plugin.layout
     dash_duo.start_server(app)
 
     # Test statistics plot.
+    dash_duo.find_element("#{} label:nth-child({})".format(plugin.radio_id, 1)).click()
     dash_duo.select_dcc_dropdown("#{}".format(plugin.key_dropdown_id), "key1")
 
     # Test data plot.
     dash_duo.find_element("#{} label:nth-child({})".format(plugin.radio_id, 2)).click()
+
+    # Test filtering realizations.
+    dash_duo.find_element(
+        "#{} label:nth-child({})".format(plugin.realization_filter_check_id, 1)
+    ).click()
+    dash_duo.find_element("#{}".format(plugin.realization_filter_input_id)).send_keys(
+        "1, 3"
+    )
 
     # Clear the axes dropdowns, which should not cause an error.
     #

--- a/tests/unit/test_objective_plot_data.py
+++ b/tests/unit/test_objective_plot_data.py
@@ -1,6 +1,5 @@
 import os
 
-import pytest
 import pandas as pd
 import numpy as np
 
@@ -12,7 +11,7 @@ from everviz.pages.objectives import (
     _total_objective_values,
 )
 
-from everviz.plugins.objectives_plot.util import calculate_statistics, parse_range
+from everviz.plugins.objectives_plot.util import calculate_statistics
 
 OBJECTIVES = [
     {
@@ -153,26 +152,6 @@ def test_objective_statistics_content():
     assert objective_statistics["Mean"].to_list() == mean
     assert objective_statistics["P10"].to_list() == p10
     assert objective_statistics["P90"].to_list() == p90
-
-
-@pytest.mark.parametrize(
-    "input_string, expected",
-    [
-        ("", set()),
-        (" ", set()),
-        ("1,2,3", {1, 2, 3}),
-        ("1, 2 ,3", {1, 2, 3}),
-        ("3,1,2", {1, 2, 3}),
-        ("3,1,3", {1, 3}),
-        ("1-3", {1, 2, 3}),
-        ("1, 2-3", {1, 2, 3}),
-        ("1, 1-3, 2", {1, 2, 3}),
-        ("x", set()),
-        ("1,2,x,3", {1, 2, 3}),
-    ],
-)
-def test_object_parse_range(input_string, expected):
-    assert parse_range(input_string) == expected
 
 
 def test_set_up_sources(mocker, monkeypatch, tmpdir):

--- a/tests/unit/test_summary_plot.py
+++ b/tests/unit/test_summary_plot.py
@@ -3,11 +3,8 @@ from datetime import datetime
 import pandas as pd
 import numpy as np
 
-from everviz.pages.summary_values import (
-    page_layout,
-    _summary_values,
-    _summary_statistics,
-)
+from everviz.pages.summary_values import page_layout, _summary_values
+from everviz.plugins.summary_plot.util import calculate_statistics
 
 __TEST_DATA = {
     "realization": range(12),
@@ -57,7 +54,8 @@ def test_summary_values_data_frame():
 
 def test_summary_statistics_data_frame():
     """Test for the correct layout and size of the summary statistics data frame"""
-    summary_statistics = _summary_statistics(pd.DataFrame(__TEST_DATA))
+    summary_values = _summary_values(pd.DataFrame(__TEST_DATA))
+    summary_statistics = calculate_statistics(summary_values)
 
     assert list(summary_statistics.columns) == [
         "summary_key",
@@ -77,7 +75,8 @@ def test_summary_statistics_data_frame():
 
 def test_summary_statistics_content():
     """Test for the correct content of the summary statistics data frame."""
-    summary_statistics = _summary_statistics(pd.DataFrame(__TEST_DATA))
+    summary_values = _summary_values(pd.DataFrame(__TEST_DATA))
+    summary_statistics = calculate_statistics(summary_values)
 
     mean = []
     p10 = []

--- a/tests/unit/test_util.py
+++ b/tests/unit/test_util.py
@@ -1,6 +1,6 @@
 import os
 import pytest
-from everviz.util import get_everviz_folder
+from everviz.util import get_everviz_folder, parse_range
 
 
 @pytest.fixture
@@ -18,3 +18,23 @@ def test_get_everviz_folder(tmpdir, mocked_api):
         everviz_path = get_everviz_folder(mocked_api)
         assert os.path.exists(everviz_path)
         assert expected_everviz_path == everviz_path
+
+
+@pytest.mark.parametrize(
+    "input_string, expected",
+    [
+        ("", set()),
+        (" ", set()),
+        ("1,2,3", {1, 2, 3}),
+        ("1, 2 ,3", {1, 2, 3}),
+        ("3,1,2", {1, 2, 3}),
+        ("3,1,3", {1, 3}),
+        ("1-3", {1, 2, 3}),
+        ("1, 2-3", {1, 2, 3}),
+        ("1, 1-3, 2", {1, 2, 3}),
+        ("x", set()),
+        ("1,2,x,3", {1, 2, 3}),
+    ],
+)
+def test_object_parse_range(input_string, expected):
+    assert parse_range(input_string) == expected


### PR DESCRIPTION
Add the ability to filter realizations using a comma seperated string of indices and ranges, following the same approach as used for the objective function plots.

closes #105 