### PR TITLE
Revert "Drop support for Python 3.6/3.7"

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -8,7 +8,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [3.8]
+        python-version: [3.6, 3.7, 3.8]
         os: [ubuntu-latest]
 
     runs-on: ${{ matrix.os }}

--- a/README.md
+++ b/README.md
@@ -30,12 +30,12 @@ pip install tox
 tox
 ```
 
-or to run it for a particular Python version (in this case Python 3.8):
+or to run it for a particular Python version (in this case Python 3.7):
 
 ```sh
 # Test
 pip install tox
-tox -e py38
+tox -e py37
 ```
 
 [pytest](https://docs.pytest.org/en/latest/) is used as the test runner, so for quicker

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,10 @@ setup(
     author="Software Innovation Bergen, Equinor ASA",
     license="AGPL-3.0",
     url="https://github.com/equinor/everviz",
-    setup_requires=["setuptools_scm"],
+    setup_requires=[
+        "setuptools_scm<7; python_version<'3.7'",
+        "setuptools_scm; python_version>='3.7'",
+    ],
     install_requires=[
         "pyyaml",
         "pandas",

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,8 @@ setup(
     use_scm_version={"write_to": "everviz/version.py"},
     classifiers=[
         "Programming Language :: Python",
-        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.6",
+        "Programming Language :: Python :: 3.7",
     ],
     entry_points={
         "webviz_config_plugins": [

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 # content of: tox.ini , put in same dir as setup.py
 [tox]
 envlist = 
-    py{38}
+    py{36,37,38}
     linting
     docs
     formatting
@@ -45,4 +45,6 @@ commands = sphinx-build -W -b html -d {envtmpdir}/doctrees docs {envtmpdir}/html
 
 [gh-actions]
 python =
+    3.6: py36
+    3.7: py37
     3.8: py38


### PR DESCRIPTION
This reverts commit 84c52df7260020e41d1954696764d3bdcce6ed02.

The Python 3.8 komodo bleeding installation is broken for Everest, hence we must revert to 3.6 for  now.
