### PR TITLE
Fix delta plots when no summary values are present

### DIFF
--- a/everviz/pages/deltaplot.py
+++ b/everviz/pages/deltaplot.py
@@ -21,9 +21,11 @@ def _get_objective_delta_values(api, best_batch):
 
 
 def _get_summary_delta_values(api, best_batch):
+    summary = api.summary_values()
+    if summary.empty:
+        return summary
     data = (
-        api.summary_values()
-        .drop(columns="simulation")
+        summary.drop(columns="simulation")
         .set_index(["realization", "date"])
         .dropna(axis=1, how="all")
     )


### PR DESCRIPTION
There was a small bug when trying to plot a case with summary values. This not detected by the delta plots and hence led to an exception. This PR makes fixes that.